### PR TITLE
Improve decoding JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-05-17
+### Added
+* You can now optionally pass a PSR-3 LoggerInterface to the `SchemaOrg` class, so it'll log decoding errors.
+
+### Fixed
+* The `Json` class from the crwlr/utils is now used to decode JSON strings. It tries to fix keys without quotes, which is allowed in relaxed JSON. Further, JSON-LD <script> blocks containing an invalid JSON string are ignored and don't lead to an error anymore.
+
 ## [0.1.0] - 2022-09-22
 Initial version containing `SchemaOrg` class that finds schema.org JSON-LD objects in HTML documents and converts them to instances of the classes from the spatie schema-org package.

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php": "^8.0",
         "spatie/schema-org": "~3.11.0",
-        "symfony/dom-crawler": "^6.1",
+        "symfony/dom-crawler": "^6.0",
         "crwlr/utils": "^1.0",
         "psr/log": "^2.0|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
     "require": {
         "php": "^8.0",
         "spatie/schema-org": "~3.11.0",
-        "symfony/dom-crawler": "^6.1"
+        "symfony/dom-crawler": "^6.1",
+        "crwlr/utils": "^1.0",
+        "psr/log": "^2.0|^3.0"
     },
     "require-dev": {
         "pestphp/pest": "^1.22",


### PR DESCRIPTION
The `Json` class from the crwlr/utils is now used to decode JSON strings. It tries to fix keys without quotes, which is allowed in relaxed JSON. Further, JSON-LD <script> blocks containing an invalid JSON string are ignored and don't lead to an error anymore.

Also, you can now pass a PSR-3 LoggerInterface to the `SchemaOrg` class, so it'll log decoding errors.