### PR TITLE
Fix parsing objects with non-string type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2022-05-17
+## [0.2.1] - 2023-05-25
+### Fixed
+* If a schema.org object has a non string @type, it is ignored and a warning is logged, if the class has a logger.
+
+## [0.2.0] - 2023-05-17
 ### Added
 * You can now optionally pass a PSR-3 LoggerInterface to the `SchemaOrg` class, so it'll log decoding errors.
 

--- a/src/SchemaOrg.php
+++ b/src/SchemaOrg.php
@@ -83,6 +83,12 @@ class SchemaOrg
             return null;
         }
 
+        if (!is_string($json['@type'])) {
+            $this->logger?->warning('Can\'t convert schema.org object with non-string type.');
+
+            return null;
+        }
+
         $className = $this->types->getClassName($json['@type']);
 
         if (!$className) {

--- a/tests/SchemaOrgTest.php
+++ b/tests/SchemaOrgTest.php
@@ -185,6 +185,31 @@ test('there is no error if a json-ld script block contains an invalid JSON strin
     expect($schemaOrgObjects)->toBeEmpty();
 });
 
+it('returns null if the schema.org object doesn\'t have a distinct type', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html lang="de-AT">
+        <head>
+        <title>Hello world</title>
+        </head>
+        <body>
+        <script type="application/ld+json">
+        {
+            "@context": "http://schema.org",
+            "@type": ["CreativeWork", "Product"],
+            "name" : "something",
+            "productID": "123abc"
+        }
+        </script>
+        </body>
+        </html>
+        HTML;
+
+    $schemaOrgObjects = SchemaOrg::fromHtml($html);
+
+    expect($schemaOrgObjects)->toBeEmpty();
+});
+
 test('you can pass it a PSR-3 LoggerInterface and it will log an error message for invalid JSON string', function () {
     $scriptBlockContent = <<<INVALIDJSON
         {


### PR DESCRIPTION
If a schema.org object has a non string @type, it is ignored and a warning is logged, if the class has a logger.