### PR TITLE
Fix parsing graph property with single object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2025-04-08
+### Fixed
+* An error when a `@graph` property contains only a single object instead of an array of objects. See issue: https://github.com/crwlrsoft/schema-org/issues/7
+
 ## [0.3.3] - 2025-01-10
 ### Fixed
 * Enable reading multiple schema.org objects from a JSON-LD script block containing an array of schema.org objects.

--- a/src/SchemaOrg.php
+++ b/src/SchemaOrg.php
@@ -113,8 +113,19 @@ class SchemaOrg
     {
         $schemaOrgObjects = [];
 
-        foreach ($jsonData->getGraph() as $graphDataItem) {
-            $schemaOrgObject = $this->convertJsonDataToSchemaOrgObject($graphDataItem);
+        if ($jsonData->getGraph()->isNumericArray()) {
+            foreach ($jsonData->getGraph() as $graphDataItem) {
+                $schemaOrgObject = $this->convertJsonDataToSchemaOrgObject($graphDataItem);
+
+                if ($schemaOrgObject) {
+                    $schemaOrgObjects[] = $schemaOrgObject;
+                }
+            }
+        } else {
+            // When someone provides a structure where the @graph key contains a single object
+            // instead of an array of objects, it should still work. See issue:
+            // https://github.com/crwlrsoft/schema-org/issues/7
+            $schemaOrgObject = $this->convertJsonDataToSchemaOrgObject($jsonData->getGraph());
 
             if ($schemaOrgObject) {
                 $schemaOrgObjects[] = $schemaOrgObject;


### PR DESCRIPTION
Fixes an error when a `@graph` property contains only a single object instead of an array of objects.
Solves issue: https://github.com/crwlrsoft/schema-org/issues/7